### PR TITLE
Make UI string can be translated

### DIFF
--- a/master-post-password.php
+++ b/master-post-password.php
@@ -109,7 +109,7 @@ class c2c_MasterPostPassword {
 		}
 
 		register_setting( 'reading', self::$setting_name );
-		add_settings_field( self::$setting_name, __( 'Master Post Password', 'master-post-password' ), array( $this, 'display_option' ), 'reading' );
+		add_settings_field( self::$setting_name, _x( 'Master Post Password', 'UI String', 'master-post-password' ), array( $this, 'display_option' ), 'reading' );
 	}
 
 	/**


### PR DESCRIPTION
The UI string "Master Post Password" which is displayed on Reading page is the same as the plugin name. we don't translate the plugin name for zh_TW, but the UI string displayed on Reading page should be translated, so I made this PR.